### PR TITLE
Fix discovery_info key for HyperHDR configuration flow

### DIFF
--- a/custom_components/hyperhdr/config_flow.py
+++ b/custom_components/hyperhdr/config_flow.py
@@ -217,7 +217,7 @@ class HyperHDRConfigFlow(ConfigFlow, domain=DOMAIN):
         except ValueError:
             self._data[CONF_PORT] = const.DEFAULT_PORT_JSON
 
-        if not (hyperhdr_id := discovery_info.upnp.get(ssdp.ATTR_UPNP_SERIAL)):
+        if not (hyperhdr_id := discovery_info.upnp.get("serialNumber")):
             return self.async_abort(reason="no_id")
 
         # For discovery mechanisms, we set the unique_id as early as possible to


### PR DESCRIPTION
Summary of what was wrong and what was changed:

Cause: The code used ssdp.ATTR_UPNP_SERIAL, but the homeassistant.components.ssdp module doesn’t define that constant, which triggers the AttributeError.

Fix: Use the real key from the SSDP/UPnP payload. Your comment in the same file shows the discovery payload uses 'serialNumber' (e.g. 'serialNumber': 'f9aab089-f85a-55cf-b7c1-222a72faebe9'). The code was updated to use that key directly:

Before: discovery_info.upnp.get(ssdp.ATTR_UPNP_SERIAL)
After: discovery_info.upnp.get("serialNumber")
So the unique ID is still read from the UPnP serial number, but via the correct key. After updating the integration (and restarting or reloading if needed), SSDP discovery for HyperHDR should work without that error.