### PR TITLE
fix: prevent HACS double-nesting by zipping integration files at archive root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,10 +132,10 @@ jobs:
             fi
           fi
 
-          # HACS zip_release (hacs.json): archive must unpack to custom_components/hyperhdr/
+          # HACS zip_release (hacs.json): zip files at archive root so HACS can extract directly into custom_components/hyperhdr/
           rm -f hyperhdr.zip
-          zip -r hyperhdr.zip custom_components/hyperhdr \
-            -x "*__pycache__/*" -x "*.pyc"
+          (cd custom_components/hyperhdr && zip -r ../../hyperhdr.zip . \
+            -x "*__pycache__/*" -x "*.pyc")
 
           EXTRA=( )
           if [ "$INPUT_DRAFT" = "true" ]; then EXTRA+=(--draft); fi
@@ -180,7 +180,7 @@ jobs:
             echo ""
             echo "**Draft releases** use a temporary \`untagged-…\` URL in the job log until you **Publish** the release on GitHub; then the normal \`/releases/tag/${TAG}\` link applies."
             echo ""
-            echo "Release asset **\`hyperhdr.zip\`** (HACS \`zip_release\`) contains \`custom_components/hyperhdr/\` for extraction into the Home Assistant config directory."
+            echo "Release asset **\`hyperhdr.zip\`** (HACS \`zip_release\`) contains integration files at archive root — HACS extracts them directly into \`custom_components/hyperhdr/\`."
             echo ""
             echo "### PR checks"
             echo "If required checks were stuck: GitHub often **does not run** \`pull_request\` workflows for commits pushed with the default \`GITHUB_TOKEN\`. This workflow **dispatches Validate** on the release branch when secret \`WORKFLOW_TRIGGER_TOKEN\` is unset. Optionally add that repo secret (PAT with **contents** + **pull requests**, and **actions** if you use fine-grained) so push/PR use a non-GitHub Actions identity and checks start automatically like a normal PR."

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Restart Home Assistant after installation. For setup and troubleshooting, see th
 
 ### Manually (not recommended)
 
-- Download the [latest release](https://github.com/Shaffer-Softworks/hyperhdr-ha/releases) as a **zip file** then extract it and move the `hyperhdr` folder into the `custom_components` folder in your Home Assistant installation.
+- Download the [latest release](https://github.com/Shaffer-Softworks/hyperhdr-ha/releases) as a **zip file**, create a folder named `hyperhdr` inside the `custom_components` folder in your Home Assistant installation, then extract the zip contents directly into that folder.
 - Restart Home Assistant to load the integration.
 
 **Dependencies**: This integration requires `hyperhdr-py-sickkick==0.2.0`. When installing via HACS, the package is installed automatically. For manual installation, ensure your Home Assistant environment has this package available.


### PR DESCRIPTION
## Summary

- The release workflow was running `zip -r hyperhdr.zip custom_components/hyperhdr` from the repo root, embedding the full `custom_components/hyperhdr/` path in the archive
- HACS `zip_release` extracts the zip directly into `custom_components/hyperhdr/`, causing double-nesting: `custom_components/hyperhdr/custom_components/hyperhdr/manifest.json`
- Home Assistant could not find the integration, reporting: *Unable to get manifest for integration hyperhdr: Integration 'hyperhdr' not found*

## Changes

- **`.github/workflows/release.yml`**: Run `zip` from inside `custom_components/hyperhdr/` via subshell so archive entries are at the root (`manifest.json`, `__init__.py`, `translations/`, etc.) — no path prefix
- **`README.md`**: Update manual install instructions to match the new zip structure (no top-level `hyperhdr/` folder; users create the folder and extract contents into it)
