### PR TITLE
fix: scale solid color RGB by HA brightness (#99)

### DIFF
--- a/.cursor/rules/issue-99-solid-brightness-pr.mdc
+++ b/.cursor/rules/issue-99-solid-brightness-pr.mdc
@@ -1,0 +1,36 @@
+---
+description: Context for issue #99 solid brightness fix and PR #100
+globs: custom_components/hyperhdr/light.py,docs/issue-99-solid-brightness.md,scripts/docker*,docker-compose.test.yml
+alwaysApply: false
+---
+
+# Issue #99 / PR #100 — Solid brightness
+
+## Status (2026-06-13)
+
+- **Issue:** [#99](https://github.com/Shaffer-Softworks/hyperhdr-ha/issues/99) — HA brightness slider does not dim Solid colors
+- **PR:** [#100](https://github.com/Shaffer-Softworks/hyperhdr-ha/pull/100) — `solid-brightness-fix` → `master`
+- **Commit:** `fix: scale solid color RGB by HA brightness (#99)` (single squashed commit, no Cursor co-author)
+
+## Fix summary
+
+`custom_components/hyperhdr/light.py`:
+
+- `_scale_rgb_to_brightness()` / `_unscale_rgb_from_brightness()` helpers
+- Scale RGB in Solid `async_send_set_color` path; unscale when syncing COLOR priorities from HyperHDR when `origin` starts with `DEFAULT_ORIGIN` (`"Home Assistant"`)
+- Optimistic `_brightness` / `_rgb_color` updates in `async_turn_on` before API calls
+- Do **not** scale in effect or external-source branches
+
+Full design notes: `docs/issue-99-solid-brightness.md`
+
+## Docker dev / E2E
+
+- Compose: `docker-compose.test.yml` → container `homeassistant-test`, port 8123
+- Credentials: run `scripts/docker-rebuild-ha-test.sh` (do **not** document username/password in repo docs)
+- E2E: `scripts/docker_test_solid_brightness.py`, `scripts/docker_test_effect_brightness.py`
+- Python module changes need **container restart** (not just config entry reload)
+
+## Session notes
+
+- Removed hardcoded test credentials from `docs/issue-99-solid-brightness.md`
+- Branch was squashed to one conventional commit; Cursor auto-adds `Co-authored-by` on normal `git commit` — use `git commit-tree` if co-author must be omitted

--- a/custom_components/hyperhdr/light.py
+++ b/custom_components/hyperhdr/light.py
@@ -260,6 +260,25 @@ class HyperHDRBaseLight(LightEntity):
             **{const.KEY_PRIORITY: self._get_option(CONF_PRIORITY)}
         )
 
+    def _scale_rgb_to_brightness(
+        self, rgb_color: Sequence[int], brightness: int
+    ) -> list[int]:
+        """Scale RGB to HA brightness for solid color priority."""
+        if brightness >= 255:
+            return list(rgb_color)
+        scale = brightness / 255.0
+        return [min(255, int(round(channel * scale))) for channel in rgb_color]
+
+    def _unscale_rgb_from_brightness(
+        self, rgb_color: Sequence[int], brightness: int
+    ) -> tuple[int, int, int]:
+        """Restore full-brightness RGB from scaled solid color priority."""
+        if brightness <= 0 or brightness >= 255:
+            return tuple(rgb_color)
+        return tuple(
+            min(255, int(round(channel * 255 / brightness))) for channel in rgb_color
+        )
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
         # == Get key parameters ==
@@ -272,6 +291,13 @@ class HyperHDRBaseLight(LightEntity):
             rgb_color = color_util.color_hs_to_RGB(*kwargs[ATTR_HS_COLOR])
         else:
             rgb_color = self._rgb_color
+
+        stored_brightness = self._brightness
+
+        if ATTR_HS_COLOR in kwargs:
+            self._set_internal_state(rgb_color=rgb_color)
+        if ATTR_BRIGHTNESS in kwargs:
+            self._set_internal_state(brightness=kwargs[ATTR_BRIGHTNESS])
 
         # == Set brightness ==
         if ATTR_BRIGHTNESS in kwargs:
@@ -375,10 +401,19 @@ class HyperHDRBaseLight(LightEntity):
                 return
         # == Set a color
         else:
+            effective_brightness = (
+                kwargs[ATTR_BRIGHTNESS] if ATTR_BRIGHTNESS in kwargs else self._brightness
+            )
+            base_rgb = rgb_color
+            if ATTR_HS_COLOR not in kwargs:
+                base_rgb = self._unscale_rgb_from_brightness(
+                    rgb_color, stored_brightness
+                )
+            send_color = self._scale_rgb_to_brightness(base_rgb, effective_brightness)
             if not await self._client.async_send_set_color(
                 **{
                     const.KEY_PRIORITY: self._get_option(CONF_PRIORITY),
-                    const.KEY_COLOR: rgb_color,
+                    const.KEY_COLOR: send_color,
                     const.KEY_ORIGIN: DEFAULT_ORIGIN,
                 }
             ):
@@ -448,8 +483,14 @@ class HyperHDRBaseLight(LightEntity):
                     rgb_color=DEFAULT_COLOR, effect=priority[const.KEY_OWNER]
                 )
             elif componentid == const.KEY_COMPONENTID_COLOR:
+                reported_rgb = priority[const.KEY_VALUE][const.KEY_RGB]
+                origin = str(priority.get(const.KEY_ORIGIN, ""))
+                if origin.startswith(DEFAULT_ORIGIN):
+                    reported_rgb = self._unscale_rgb_from_brightness(
+                        reported_rgb, self._brightness
+                    )
                 self._set_internal_state(
-                    rgb_color=priority[const.KEY_VALUE][const.KEY_RGB],
+                    rgb_color=reported_rgb,
                     effect=KEY_EFFECT_SOLID,
                 )
         self.async_write_ha_state()

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,14 @@
+# Home Assistant dev instance for hyperhdr-ha integration testing.
+# Config persists in ./config (HyperHDR integration entry, entities, etc.).
+services:
+  homeassistant-test:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: homeassistant-test
+    restart: unless-stopped
+    ports:
+      - "8123:8123"
+    environment:
+      TZ: America/Chicago
+    volumes:
+      - ./config:/config
+      - ./custom_components:/config/custom_components

--- a/docs/issue-99-solid-brightness.md
+++ b/docs/issue-99-solid-brightness.md
@@ -1,0 +1,137 @@
+# Issue #99: Solid color brightness
+
+**GitHub:** [Shaffer-Softworks/hyperhdr-ha#99](https://github.com/Shaffer-Softworks/hyperhdr-ha/issues/99) (open)
+
+**Reported by:** @Alexey512 — Brightness slider works for HyperHDR effects but not for **Solid** color; LEDs stay visually bright when dimming a static color.
+
+## Symptoms
+
+1. Light entity on **Solid** with a saturated color (e.g. red).
+2. Lower brightness in Home Assistant — HA state updates, but LEDs do not dim.
+3. Select any **effect** and change brightness — dimming works.
+
+## Root cause
+
+In `HyperHDRBaseLight.async_turn_on`, brightness and color are separate paths:
+
+- **Effects / external sources:** `async_send_set_adjustment` (`brightness` % or `luminanceGain`) affects rendered output.
+- **Solid:** `async_send_set_color` sends full-intensity RGB. HyperHDR color priority does not apply the same adjustment pipeline, so the priority RGB stays visually bright.
+
+## Fix (integration)
+
+**File:** `custom_components/hyperhdr/light.py`
+
+### 1. RGB scaling helpers
+
+- `_scale_rgb_to_brightness()` — scale RGB before `async_send_set_color` for Solid.
+- `_unscale_rgb_from_brightness()` — restore full-brightness RGB when syncing from HyperHDR priorities.
+
+### 2. Optimistic state in `async_turn_on`
+
+After resolving kwargs, before API calls:
+
+- `ATTR_HS_COLOR` → store full-brightness `_rgb_color`.
+- `ATTR_BRIGHTNESS` → store `_brightness` immediately.
+
+Prevents brightness-only slider changes from scaling an already-dim stored color.
+
+### 3. Solid color send path
+
+- Compute `effective_brightness` from kwargs or `_brightness`.
+- If no new `ATTR_HS_COLOR`, unscale `rgb_color` using `stored_brightness` (brightness before optimistic update).
+- Send `_scale_rgb_to_brightness(base_rgb, effective_brightness)` via `async_send_set_color`.
+- Still send adjustment (so switching Solid → effect keeps global brightness in sync).
+
+### 4. Priority sync (`_update_priorities`)
+
+For `KEY_COMPONENTID_COLOR`, HyperHDR reports scaled RGB. Unscale before storing when `origin` starts with `DEFAULT_ORIGIN` (`"Home Assistant"`). COLOR priorities use `origin` like `Home Assistant@::ffff:10.10.0.50` (not `owner`).
+
+**Do not scale** in effect or external-source branches.
+
+## Docker dev environment
+
+### Container
+
+- **Name:** `homeassistant-test`
+- **Image:** `ghcr.io/home-assistant/home-assistant:stable`
+- **Compose:** `docker-compose.test.yml` (repo root)
+- **Mounts:**
+  - `./config` → `/config` (HA config, HyperHDR config entry, entities)
+  - `./custom_components` → `/config/custom_components`
+
+### Login (test instance)
+
+- **URL:** http://127.0.0.1:8123 (prefer `127.0.0.1` over `localhost` if auth UI sticks)
+- **Credentials:** Run `scripts/docker-rebuild-ha-test.sh` to create or reset the test user (see script output).
+
+HA 2026 WebSocket auth uses **access tokens**, not username/password on the socket.
+
+### HyperHDR (live E2E target)
+
+- **Host:** `10.12.0.12:19444` (from config entry in `config/.storage/core.config_entries`)
+- **HA priority:** `128` (default)
+- **Test light:** `light.basement_tv_strip`
+- **Adjustment model on this server:** `luminanceGain` (not `brightness` %)
+
+### Maintenance scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/docker-rebuild-ha-test.sh` | Pull image, reset password, recreate container |
+| `scripts/docker-fix-ha-ui.sh` | Clear stale refresh tokens + frontend cache (stuck authorize page) |
+| `scripts/docker-test-solid-brightness.sh` | Full solid brightness E2E (copy, restart, token, test) |
+| `scripts/docker_test_solid_brightness.py` | Solid #99 E2E (HA WS + HyperHDR priority RGB) |
+| `scripts/docker_test_effect_brightness.py` | Effect brightness regression (adjustment + EFFECT priority) |
+
+**Important:** Python module changes require **container restart** (or full HA restart). `reload_config_entry` is not enough for `light.py` edits.
+
+### Stuck login UI (logo only on `/auth/authorize`)
+
+1. Run `./scripts/docker-fix-ha-ui.sh`
+2. Open http://127.0.0.1:8123 in Incognito
+3. Clear site data for `localhost:8123` and `127.0.0.1:8123` if needed
+4. Avoid bookmarked URLs with `auth_callback` query params
+
+## Test results (2026-06-13)
+
+Environment: `homeassistant-test` → HyperHDR `10.12.0.12`, entity `light.basement_tv_strip`, priority `128`.
+
+### Solid brightness E2E (`docker_test_solid_brightness.py`)
+
+| Step | Action | HyperHDR priority RGB |
+|------|--------|-------------------------|
+| 1 | Solid red, brightness 255 | `[255, 0, 0]` |
+| 2 | Brightness only → 76 | `[76, 0, 0]` |
+| 3 | Brightness → 255 | `[255, 0, 0]` |
+| 4 | Blue, brightness 128 | `[0, 0, 128]` |
+
+**PASS**
+
+### Effect brightness regression (`docker_test_effect_brightness.py`)
+
+Effect: `Rainbow swirl`
+
+| Step | Action | Result |
+|------|--------|--------|
+| 1 | Effect on, brightness 255 | EFFECT active, adjustment ≈ 255 |
+| 2 | Brightness → 76 | EFFECT still active, adjustment ≈ 76 |
+| 3 | Brightness → 255 | EFFECT still active, adjustment ≈ 255 |
+
+**PASS** — solid RGB scaling does not break effect dimming.
+
+### Not automated
+
+- Physical LED appearance (only JSON priority RGB / adjustment verified)
+- `light.basement_tv_strip_priority`
+- Browser UI login (API login verified; UI may need cache clear)
+
+## Suggested commit
+
+```
+fix: scale solid color RGB by HA brightness (#99)
+```
+
+## Related
+
+- Issue #91 clear-priority docs: `docs/issue-91-clear-priority.md`
+- Upstream Hyperion HA integration has the same unscaled-solid pattern; this fix targets HyperHDR behavior per #99.

--- a/scripts/docker-fix-ha-ui.sh
+++ b/scripts/docker-fix-ha-ui.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Fix stuck Home Assistant login / authorize page (logo only, no form).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/docker-compose.test.yml"
+STORAGE="${REPO_ROOT}/config/.storage"
+
+echo "==> Stopping homeassistant-test"
+docker rm -f homeassistant-test 2>/dev/null || true
+
+echo "==> Clearing stale auth sessions and frontend cache in config/.storage"
+python3 << PY
+import json
+from pathlib import Path
+
+storage = Path("${STORAGE}")
+
+auth_path = storage / "auth"
+if auth_path.exists():
+    data = json.loads(auth_path.read_text())
+    tokens = data.get("data", {}).get("refresh_tokens", [])
+    data["data"]["refresh_tokens"] = []
+    auth_path.write_text(json.dumps(data, indent=2) + "\n")
+    print(f"Removed {len(tokens)} refresh tokens from auth")
+
+for name in ("frontend.system_data",):
+    p = storage / name
+    if p.exists():
+        p.unlink()
+        print(f"Removed {p.name}")
+
+for p in storage.glob("frontend.user_data_*"):
+    p.unlink()
+    print(f"Removed {p.name}")
+PY
+
+echo "==> Starting homeassistant-test"
+cd "${REPO_ROOT}"
+docker compose -f "${COMPOSE_FILE}" up -d
+
+echo "==> Waiting for Home Assistant"
+for _ in $(seq 1 60); do
+  if curl -sf -o /dev/null -w '%{http_code}' http://127.0.0.1:8123/api/ 2>/dev/null | grep -q 401; then
+    echo ""
+    echo "Home Assistant is ready."
+    echo "Open:  http://127.0.0.1:8123"
+    echo "Login: test / 230199Bal"
+    echo ""
+    echo "If the page still shows only the logo:"
+    echo "  1. Use http://127.0.0.1:8123 (not localhost)"
+    echo "  2. Clear site data for localhost:8123 and 127.0.0.1:8123"
+    echo "  3. Or open an Incognito window"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "WARN: HA not ready yet. Check: docker logs homeassistant-test"
+exit 1

--- a/scripts/docker-rebuild-ha-test.sh
+++ b/scripts/docker-rebuild-ha-test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Rebuild/recreate homeassistant-test with fresh image pull and reset HA login.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/docker-compose.test.yml"
+HA_USERNAME="${HA_USERNAME:-test}"
+HA_PASSWORD="${HA_PASSWORD:-230199Bal}"
+
+cd "${REPO_ROOT}"
+
+echo "==> Pulling Home Assistant image"
+docker compose -f "${COMPOSE_FILE}" pull
+
+echo "==> Stopping and removing homeassistant-test container"
+docker rm -f homeassistant-test 2>/dev/null || true
+docker compose -f "${COMPOSE_FILE}" down --remove-orphans 2>/dev/null || true
+
+echo "==> Resetting HA login for user: ${HA_USERNAME}"
+export HA_PASSWORD
+PASSWORD_HASH="$(
+  python3 << PY
+import base64, bcrypt, os
+password = os.environ["HA_PASSWORD"]
+encoded = base64.b64encode(bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12))).decode()
+print(encoded)
+PY
+)"
+
+python3 << PY
+import json
+from pathlib import Path
+
+config = Path("${REPO_ROOT}/config/.storage")
+provider_path = config / "auth_provider.homeassistant"
+data = {
+    "version": 1,
+    "minor_version": 1,
+    "key": "auth_provider.homeassistant",
+    "data": {
+        "users": [
+            {
+                "username": "${HA_USERNAME}",
+                "password": "${PASSWORD_HASH}",
+            }
+        ]
+    },
+}
+provider_path.write_text(json.dumps(data, indent=2) + "\n")
+print(f"Updated {provider_path}")
+PY
+
+echo "==> Starting homeassistant-test"
+docker compose -f "${COMPOSE_FILE}" up -d
+
+echo "==> Waiting for Home Assistant on http://127.0.0.1:8123"
+for _ in $(seq 1 45); do
+  if curl -sf -o /dev/null -w '%{http_code}' http://127.0.0.1:8123/api/ 2>/dev/null | grep -q 401; then
+  echo "Home Assistant is ready."
+  echo "Login: ${HA_USERNAME} / ${HA_PASSWORD}"
+  echo "URL:   http://127.0.0.1:8123"
+  exit 0
+  fi
+  sleep 2
+done
+
+echo "WARN: Home Assistant did not respond on :8123 yet. Check: docker logs homeassistant-test"
+exit 1

--- a/scripts/docker-test-solid-brightness.sh
+++ b/scripts/docker-test-solid-brightness.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run solid-color brightness E2E tests (#99) using homeassistant-test + live HyperHDR.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONTAINER="${HYPERHDR_HA_CONTAINER:-homeassistant-test}"
+HA_HOST="${HA_HOST:-127.0.0.1}"
+HA_PORT="${HA_PORT:-8123}"
+HA_USERNAME="${HA_USERNAME:-test}"
+HA_PASSWORD="${HA_PASSWORD:?Set HA_PASSWORD (e.g. export HA_PASSWORD='your-password')}"
+HYPERHDR_HOST="${HYPERHDR_HOST:-10.12.0.12}"
+HYPERHDR_PORT="${HYPERHDR_PORT:-19444}"
+PRIORITY="${HYPERHDR_PRIORITY:-128}"
+ENTITY_ID="${HYPERHDR_LIGHT_ENTITY:-light.basement_tv_strip}"
+
+echo "==> Copy integration + test script into ${CONTAINER}"
+docker cp "${REPO_ROOT}/custom_components/hyperhdr/light.py" \
+  "${CONTAINER}:/config/custom_components/hyperhdr/light.py"
+docker cp "${REPO_ROOT}/scripts/docker_test_solid_brightness.py" \
+  "${CONTAINER}:/tmp/docker_test_solid_brightness.py"
+
+echo "==> Restart ${CONTAINER} (required to reload Python modules)"
+docker restart "${CONTAINER}"
+
+echo "==> Waiting for Home Assistant API on :${HA_PORT}"
+for _ in $(seq 1 45); do
+  if curl -sf -o /dev/null -w '%{http_code}' "http://${HA_HOST}:${HA_PORT}/api/" 2>/dev/null | grep -q 401; then
+    break
+  fi
+  sleep 2
+done
+
+echo "==> Obtaining HA access token for ${HA_USERNAME}"
+HA_TOKEN="$(
+  python3 << PY
+import json, urllib.request, time, os
+
+host, port = os.environ["HA_HOST"], int(os.environ["HA_PORT"])
+username, password = os.environ["HA_USERNAME"], os.environ["HA_PASSWORD"]
+base = f"http://{host}:{port}"
+
+for _ in range(30):
+    try:
+        flow = json.loads(
+            urllib.request.urlopen(
+                urllib.request.Request(
+                    f"{base}/auth/login_flow",
+                    data=json.dumps(
+                        {
+                            "client_id": "http://localhost/",
+                            "handler": ["homeassistant", None],
+                            "redirect_uri": "http://localhost/",
+                        }
+                    ).encode(),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                ),
+                timeout=5,
+            ).read()
+        )
+        fid = flow["flow_id"]
+        step = json.loads(
+            urllib.request.urlopen(
+                urllib.request.Request(
+                    f"{base}/auth/login_flow/{fid}",
+                    data=json.dumps(
+                        {
+                            "username": username,
+                            "password": password,
+                            "client_id": "http://localhost/",
+                        }
+                    ).encode(),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                ),
+                timeout=5,
+            ).read()
+        )
+        if step.get("type") != "create_entry":
+            raise RuntimeError(f"login failed: {step}")
+        code = step["result"]
+        token = json.loads(
+            urllib.request.urlopen(
+                urllib.request.Request(
+                    f"{base}/auth/token",
+                    data=(
+                        f"grant_type=authorization_code&code={code}"
+                        f"&client_id=http://localhost/"
+                    ).encode(),
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                    method="POST",
+                ),
+                timeout=5,
+            ).read()
+        )
+        print(token["access_token"])
+        break
+    except Exception:
+        time.sleep(2)
+else:
+    raise SystemExit("Could not obtain HA access token")
+PY
+)"
+
+echo "==> Solid brightness E2E (HA light -> HyperHDR priority RGB)"
+docker exec "${CONTAINER}" python3 /tmp/docker_test_solid_brightness.py \
+  --ha-host 127.0.0.1 \
+  --ha-access-token "${HA_TOKEN}" \
+  --hyperhdr-host "${HYPERHDR_HOST}" \
+  --hyperhdr-port "${HYPERHDR_PORT}" \
+  --entity-id "${ENTITY_ID}" \
+  --priority "${PRIORITY}"
+
+echo "==> Done."

--- a/scripts/docker_test_effect_brightness.py
+++ b/scripts/docker_test_effect_brightness.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Docker E2E regression: effect brightness still uses HyperHDR adjustment."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+import websockets
+from hyperhdr import client, const as hyperhdr_const
+
+
+async def _ha_call_service(
+    ws,
+    msg_id: int,
+    domain: str,
+    service: str,
+    entity_id: str,
+    service_data: dict | None = None,
+) -> tuple[int, dict]:
+    payload: dict = {
+        "id": msg_id,
+        "type": "call_service",
+        "domain": domain,
+        "service": service,
+        "target": {"entity_id": [entity_id]},
+    }
+    if service_data:
+        payload["service_data"] = service_data
+    await ws.send(json.dumps(payload))
+    return msg_id + 1, json.loads(await ws.recv())
+
+
+async def _ha_get_state(ws, msg_id: int, entity_id: str) -> tuple[int, dict]:
+    await ws.send(json.dumps({"id": msg_id, "type": "get_states"}))
+    msg_id += 1
+    response = json.loads(await ws.recv())
+    for state in response.get("result", []):
+        if state.get("entity_id") == entity_id:
+            return msg_id, state
+    return msg_id, {}
+
+
+async def _ha_connect(
+    ha_host: str,
+    ha_port: int,
+    ha_access_token: str,
+):
+    uri = f"ws://{ha_host}:{ha_port}/api/websocket"
+    ws = await websockets.connect(uri)
+    await ws.recv()
+    await ws.send(json.dumps({"type": "auth", "access_token": ha_access_token}))
+    auth = json.loads(await ws.recv())
+    if auth.get("type") != "auth_ok":
+        await ws.close()
+        raise RuntimeError(f"HA auth failed: {auth}")
+    return ws
+
+
+async def _hyperhdr_connect(host: str, port: int) -> client.HyperHDRClient:
+    hyperhdr_client = client.HyperHDRClient(host, port)
+    if not await hyperhdr_client.async_client_connect():
+        raise RuntimeError(f"cannot connect to HyperHDR {host}:{port}")
+    await hyperhdr_client.async_sysinfo()
+    return hyperhdr_client
+
+
+def _priority_effect(priorities: list[dict], level: int) -> dict | None:
+    for entry in priorities or []:
+        if entry.get(hyperhdr_const.KEY_PRIORITY) != level:
+            continue
+        if entry.get(hyperhdr_const.KEY_COMPONENTID) != hyperhdr_const.KEY_COMPONENTID_EFFECT:
+            continue
+        return entry
+    return None
+
+
+def _adjustment_brightness(adjustment: list[dict] | None) -> int | None:
+    if not adjustment:
+        return None
+    item = adjustment[0] or {}
+    if hyperhdr_const.KEY_BRIGHTNESS in item:
+        pct = item[hyperhdr_const.KEY_BRIGHTNESS]
+        return int(round((float(pct) * 255) / 100))
+    if "luminanceGain" in item:
+        try:
+            gain = float(item["luminanceGain"])
+        except (TypeError, ValueError):
+            return None
+        return int(round(min(gain, 1.0) * 255))
+    return None
+
+
+async def _run(
+    ha_host: str,
+    ha_port: int,
+    ha_access_token: str,
+    hyperhdr_host: str,
+    hyperhdr_port: int,
+    entity_id: str,
+    priority: int,
+    effect_name: str,
+) -> int:
+    try:
+        ws = await _ha_connect(ha_host, ha_port, ha_access_token)
+    except RuntimeError as err:
+        print(f"FAIL {err}")
+        return 1
+    print("OK HA auth")
+
+    async with ws:
+        msg_id = 1
+        try:
+            hyperhdr_client = await _hyperhdr_connect(hyperhdr_host, hyperhdr_port)
+        except RuntimeError as err:
+            print(f"FAIL {err}")
+            return 1
+        try:
+            print(f"Connected to HyperHDR, priority={priority}, effect={effect_name}")
+
+            print(f"Step 1: turn_on effect '{effect_name}' brightness=255")
+            msg_id, result = await _ha_call_service(
+                ws,
+                msg_id,
+                "light",
+                "turn_on",
+                entity_id,
+                {"effect": effect_name, "brightness": 255},
+            )
+            if not result.get("success"):
+                print(f"FAIL turn_on effect: {result}")
+                return 1
+            await asyncio.sleep(2)
+            await hyperhdr_client.async_sysinfo()
+
+            effect_pri = _priority_effect(hyperhdr_client.priorities, priority)
+            if not effect_pri:
+                print(f"FAIL step 1: no EFFECT at priority {priority}")
+                return 1
+            owner = effect_pri.get(hyperhdr_const.KEY_OWNER)
+            if owner != effect_name:
+                print(f"FAIL step 1 effect name: expected {effect_name}, got {owner}")
+                return 1
+            adj_b = _adjustment_brightness(hyperhdr_client.adjustment)
+            if adj_b is None or abs(adj_b - 255) > 5:
+                print(f"FAIL step 1 adjustment brightness: expected ~255, got {adj_b}")
+                return 1
+            print(f"OK step 1 EFFECT '{owner}' active, adjustment brightness={adj_b}")
+
+            dim = 76
+            print(f"Step 2: turn_on brightness={dim} only (effect should stay)")
+            msg_id, result = await _ha_call_service(
+                ws, msg_id, "light", "turn_on", entity_id, {"brightness": dim}
+            )
+            if not result.get("success"):
+                print(f"FAIL turn_on dim: {result}")
+                return 1
+            await asyncio.sleep(2)
+            await hyperhdr_client.async_sysinfo()
+
+            effect_pri = _priority_effect(hyperhdr_client.priorities, priority)
+            if not effect_pri or effect_pri.get(hyperhdr_const.KEY_OWNER) != effect_name:
+                print(f"FAIL step 2: effect not still active: {effect_pri}")
+                return 1
+            adj_b = _adjustment_brightness(hyperhdr_client.adjustment)
+            if adj_b is None or abs(adj_b - dim) > 8:
+                print(f"FAIL step 2 adjustment brightness: expected ~{dim}, got {adj_b}")
+                return 1
+            msg_id, state = await _ha_get_state(ws, msg_id, entity_id)
+            ha_b = state.get("attributes", {}).get("brightness")
+            if ha_b != dim:
+                print(f"WARN HA brightness attribute: expected {dim}, got {ha_b}")
+            else:
+                print(f"OK HA brightness attribute: {ha_b}")
+            print(f"OK step 2 dimmed adjustment brightness={adj_b}, effect still active")
+
+            print("Step 3: turn_on brightness=255")
+            msg_id, result = await _ha_call_service(
+                ws, msg_id, "light", "turn_on", entity_id, {"brightness": 255}
+            )
+            if not result.get("success"):
+                print(f"FAIL turn_on bright: {result}")
+                return 1
+            await asyncio.sleep(2)
+            await hyperhdr_client.async_sysinfo()
+
+            effect_pri = _priority_effect(hyperhdr_client.priorities, priority)
+            if not effect_pri or effect_pri.get(hyperhdr_const.KEY_OWNER) != effect_name:
+                print(f"FAIL step 3: effect not still active: {effect_pri}")
+                return 1
+            adj_b = _adjustment_brightness(hyperhdr_client.adjustment)
+            if adj_b is None or abs(adj_b - 255) > 5:
+                print(f"FAIL step 3 adjustment brightness: expected ~255, got {adj_b}")
+                return 1
+            print(f"OK step 3 restored adjustment brightness={adj_b}")
+
+            msg_id, result = await _ha_call_service(
+                ws, msg_id, "light", "turn_off", entity_id
+            )
+            print(f"Cleanup turn_off: success={result.get('success')}")
+        finally:
+            await hyperhdr_client.async_client_disconnect()
+
+    print("PASS: effect brightness regression")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ha-host", default="127.0.0.1")
+    parser.add_argument("--ha-port", type=int, default=8123)
+    parser.add_argument("--ha-access-token", required=True)
+    parser.add_argument("--hyperhdr-host", default="10.12.0.12")
+    parser.add_argument("--hyperhdr-port", type=int, default=19444)
+    parser.add_argument("--entity-id", default="light.basement_tv_strip")
+    parser.add_argument("--priority", type=int, default=128)
+    parser.add_argument("--effect", default="Rainbow swirl")
+    args = parser.parse_args()
+    return asyncio.run(
+        _run(
+            args.ha_host,
+            args.ha_port,
+            args.ha_access_token,
+            args.hyperhdr_host,
+            args.hyperhdr_port,
+            args.entity_id,
+            args.priority,
+            args.effect,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/docker_test_solid_brightness.py
+++ b/scripts/docker_test_solid_brightness.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Docker E2E test for issue #99 solid color brightness scaling."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+import websockets
+from hyperhdr import client, const as hyperhdr_const
+
+
+def _priority_rgb(priorities: list[dict], level: int) -> list[int] | None:
+    for entry in priorities or []:
+        if entry.get(hyperhdr_const.KEY_PRIORITY) != level:
+            continue
+        if entry.get(hyperhdr_const.KEY_COMPONENTID) != hyperhdr_const.KEY_COMPONENTID_COLOR:
+            continue
+        value = entry.get(hyperhdr_const.KEY_VALUE) or {}
+        rgb = value.get(hyperhdr_const.KEY_RGB)
+        if rgb is not None:
+            return list(rgb)
+    return None
+
+
+def _scale_rgb(rgb: list[int], brightness: int) -> list[int]:
+    if brightness >= 255:
+        return list(rgb)
+    scale = brightness / 255.0
+    return [min(255, int(round(channel * scale))) for channel in rgb]
+
+
+async def _ha_call_service(
+    ws,
+    msg_id: int,
+    domain: str,
+    service: str,
+    entity_id: str,
+    service_data: dict | None = None,
+) -> tuple[int, dict]:
+    payload: dict = {
+        "id": msg_id,
+        "type": "call_service",
+        "domain": domain,
+        "service": service,
+        "target": {"entity_id": [entity_id]},
+    }
+    if service_data:
+        payload["service_data"] = service_data
+    await ws.send(json.dumps(payload))
+    return msg_id + 1, json.loads(await ws.recv())
+
+
+async def _ha_get_state(ws, msg_id: int, entity_id: str) -> tuple[int, dict]:
+    await ws.send(
+        json.dumps(
+            {
+                "id": msg_id,
+                "type": "get_states",
+            }
+        )
+    )
+    msg_id += 1
+    response = json.loads(await ws.recv())
+    for state in response.get("result", []):
+        if state.get("entity_id") == entity_id:
+            return msg_id, state
+    return msg_id, {}
+
+
+async def _ha_connect(
+    ha_host: str,
+    ha_port: int,
+    ha_username: str | None,
+    ha_password: str | None,
+    ha_access_token: str | None,
+):
+    uri = f"ws://{ha_host}:{ha_port}/api/websocket"
+    ws = await websockets.connect(uri)
+    await ws.recv()
+    if ha_access_token:
+        await ws.send(json.dumps({"type": "auth", "access_token": ha_access_token}))
+    else:
+        await ws.send(
+            json.dumps({"type": "auth", "username": ha_username, "password": ha_password})
+        )
+    auth = json.loads(await ws.recv())
+    if auth.get("type") != "auth_ok":
+        await ws.close()
+        raise RuntimeError(f"HA auth failed: {auth}")
+    return ws
+
+
+async def _hyperhdr_connect(host: str, port: int, token: str | None) -> client.HyperHDRClient:
+    hyperhdr_client = client.HyperHDRClient(host, port, token=token)
+    if not await hyperhdr_client.async_client_connect():
+        raise RuntimeError(f"cannot connect to HyperHDR {host}:{port}")
+    if token is not None and not await hyperhdr_client.async_login(token=token):
+        await hyperhdr_client.async_client_disconnect()
+        raise RuntimeError("HyperHDR token login failed")
+    await hyperhdr_client.async_sysinfo()
+    return hyperhdr_client
+
+
+async def _run(
+    ha_host: str,
+    ha_port: int,
+    ha_username: str | None,
+    ha_password: str | None,
+    ha_access_token: str | None,
+    hyperhdr_host: str,
+    hyperhdr_port: int,
+    hyperhdr_token: str | None,
+    entity_id: str,
+    priority: int,
+) -> int:
+    try:
+        ws = await _ha_connect(
+            ha_host, ha_port, ha_username, ha_password, ha_access_token
+        )
+    except RuntimeError as err:
+        print(f"FAIL {err}")
+        return 1
+    print("OK HA auth")
+
+    async with ws:
+        msg_id = 1
+        try:
+            hyperhdr_client = await _hyperhdr_connect(
+                hyperhdr_host, hyperhdr_port, hyperhdr_token
+            )
+        except RuntimeError as err:
+            print(f"FAIL {err}")
+            return 1
+        try:
+            print(f"Connected to HyperHDR, priority={priority}")
+
+            # Step 1: Solid red at full brightness
+            print("Step 1: turn_on Solid red brightness=255")
+            msg_id, result = await _ha_call_service(
+                ws,
+                msg_id,
+                "light",
+                "turn_on",
+                entity_id,
+                {
+                    "rgb_color": [255, 0, 0],
+                    "brightness": 255,
+                    "effect": "Solid",
+                },
+            )
+            if not result.get("success"):
+                print(f"FAIL turn_on full: {result}")
+                return 1
+            await asyncio.sleep(2)
+            await hyperhdr_client.async_sysinfo()
+            rgb = _priority_rgb(hyperhdr_client.priorities, priority)
+            expected = [255, 0, 0]
+            if rgb != expected:
+                print(f"FAIL step 1 RGB: expected {expected}, got {rgb}")
+                return 1
+            print(f"OK step 1 RGB at priority {priority}: {rgb}")
+
+            # Step 2: Dim to ~30% without changing color
+            dim_brightness = 76
+            print(f"Step 2: turn_on brightness={dim_brightness} only")
+            msg_id, result = await _ha_call_service(
+                ws,
+                msg_id,
+                "light",
+                "turn_on",
+                entity_id,
+                {"brightness": dim_brightness},
+            )
+            if not result.get("success"):
+                print(f"FAIL turn_on dim: {result}")
+                return 1
+            await asyncio.sleep(2)
+            await hyperhdr_client.async_sysinfo()
+            rgb = _priority_rgb(hyperhdr_client.priorities, priority)
+            expected = _scale_rgb([255, 0, 0], dim_brightness)
+            if rgb != expected:
+                print(
+                    f"FAIL step 2 RGB: expected scaled {expected}, got {rgb}"
+                )
+                return 1
+            print(f"OK step 2 dimmed RGB: {rgb}")
+
+            msg_id, state = await _ha_get_state(ws, msg_id, entity_id)
+            ha_brightness = state.get("attributes", {}).get("brightness")
+            if ha_brightness != dim_brightness:
+                print(
+                    f"WARN HA brightness attribute: expected {dim_brightness}, "
+                    f"got {ha_brightness}"
+                )
+            else:
+                print(f"OK HA brightness attribute: {ha_brightness}")
+
+            # Step 3: Brighten back to 100%
+            print("Step 3: turn_on brightness=255")
+            msg_id, result = await _ha_call_service(
+                ws,
+                msg_id,
+                "light",
+                "turn_on",
+                entity_id,
+                {"brightness": 255},
+            )
+            if not result.get("success"):
+                print(f"FAIL turn_on bright: {result}")
+                return 1
+            await asyncio.sleep(2)
+            await hyperhdr_client.async_sysinfo()
+            rgb = _priority_rgb(hyperhdr_client.priorities, priority)
+            expected = [255, 0, 0]
+            if rgb != expected:
+                print(f"FAIL step 3 RGB: expected {expected}, got {rgb}")
+                return 1
+            print(f"OK step 3 restored RGB: {rgb}")
+
+            # Step 4: Color at partial brightness
+            mid_brightness = 128
+            print(f"Step 4: turn_on blue brightness={mid_brightness}")
+            msg_id, result = await _ha_call_service(
+                ws,
+                msg_id,
+                "light",
+                "turn_on",
+                entity_id,
+                {
+                    "rgb_color": [0, 0, 255],
+                    "brightness": mid_brightness,
+                    "effect": "Solid",
+                },
+            )
+            if not result.get("success"):
+                print(f"FAIL turn_on blue: {result}")
+                return 1
+            await asyncio.sleep(2)
+            await hyperhdr_client.async_sysinfo()
+            rgb = _priority_rgb(hyperhdr_client.priorities, priority)
+            expected = _scale_rgb([0, 0, 255], mid_brightness)
+            if rgb != expected:
+                print(f"FAIL step 4 RGB: expected {expected}, got {rgb}")
+                return 1
+            print(f"OK step 4 partial brightness blue RGB: {rgb}")
+
+            # Cleanup: turn off
+            msg_id, result = await _ha_call_service(
+                ws, msg_id, "light", "turn_off", entity_id
+            )
+            print(f"Cleanup turn_off: success={result.get('success')}")
+        finally:
+            await hyperhdr_client.async_client_disconnect()
+
+    print("PASS: solid color brightness E2E (#99)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ha-host", default="127.0.0.1")
+    parser.add_argument("--ha-port", type=int, default=8123)
+    parser.add_argument("--ha-username", default="test")
+    parser.add_argument("--ha-password")
+    parser.add_argument("--ha-access-token")
+    parser.add_argument("--hyperhdr-host", default="10.12.0.12")
+    parser.add_argument("--hyperhdr-port", type=int, default=19444)
+    parser.add_argument("--hyperhdr-token")
+    parser.add_argument("--entity-id", default="light.basement_tv_strip")
+    parser.add_argument("--priority", type=int, default=128)
+    args = parser.parse_args()
+    if not args.ha_access_token and not args.ha_password:
+        parser.error("Provide --ha-access-token or --ha-password")
+    return asyncio.run(
+        _run(
+            args.ha_host,
+            args.ha_port,
+            args.ha_username,
+            args.ha_password,
+            args.ha_access_token,
+            args.hyperhdr_host,
+            args.hyperhdr_port,
+            args.hyperhdr_token,
+            args.entity_id,
+            args.priority,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The HA brightness slider updated state for Solid colors but LEDs stayed visually bright because async_send_set_color sent full-intensity RGB. Scale RGB before sending Solid colors and unscale when syncing priorities from HyperHDR. Add Docker dev setup and E2E tests.