### PR TITLE
fix: prevent WebSocket port from matching JSON API port

### DIFF
--- a/custom_components/hyperhdr/camera.py
+++ b/custom_components/hyperhdr/camera.py
@@ -6,6 +6,7 @@ import asyncio
 import functools
 import logging
 import time
+from typing import Any
 
 from aiohttp import web
 from hyperhdr.stream import (
@@ -55,12 +56,28 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up a HyperHDR platform from config entry."""
+    from homeassistant.const import CONF_PORT
+
     entry_data = hass.data[DOMAIN][config_entry.entry_id]
     server_id = config_entry.unique_id
     host = config_entry.data[CONF_HOST]
+    port = config_entry.data.get(CONF_PORT, 19444)
     port_ws = config_entry.data.get(CONF_PORT_WS, 8090)
     token = config_entry.data.get(CONF_TOKEN)
     admin_password = config_entry.data.get(CONF_ADMIN_PASSWORD)
+
+    # Safety check: if port_ws equals port (JSON API port), skip camera setup
+    # to prevent HTTP headers being sent to the raw JSON TCP socket
+    if port == port_ws:
+        _LOGGER.warning(
+            "WebSocket port (%s) equals JSON API port (%s) for HyperHDR at %s. "
+            "Camera entities will not be created. Please reconfigure the "
+            "integration with the correct WebSocket port (typically 8090)",
+            port_ws,
+            port,
+            host,
+        )
+        return
 
     def led_camera_unique_id(instance_num: int) -> str:
         """Return the led camera unique_id."""

--- a/custom_components/hyperhdr/config_flow.py
+++ b/custom_components/hyperhdr/config_flow.py
@@ -241,14 +241,20 @@ class HyperHDRConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle a flow initiated by the user."""
         errors = {}
         if user_input:
-            self._data.update(user_input)
+            # Validate that port and port_ws are different
+            port = user_input.get(CONF_PORT, const.DEFAULT_PORT_JSON)
+            port_ws = user_input.get(CONF_PORT_WS, DEFAULT_PORT_WS)
+            if port == port_ws:
+                errors[CONF_PORT_WS] = "ports_must_differ"
+            else:
+                self._data.update(user_input)
 
-            async with self._create_client(raw_connection=True) as hyperhdr_client:
-                if hyperhdr_client:
-                    return await self._advance_to_auth_step_if_necessary(
-                        hyperhdr_client
-                    )
-                errors[CONF_BASE] = "cannot_connect"
+                async with self._create_client(raw_connection=True) as hyperhdr_client:
+                    if hyperhdr_client:
+                        return await self._advance_to_auth_step_if_necessary(
+                            hyperhdr_client
+                        )
+                    errors[CONF_BASE] = "cannot_connect"
 
         return self.async_show_form(
             step_id="user",
@@ -488,24 +494,29 @@ class HyperHDROptionsFlow(OptionsFlow):
             if port_ws is not None:
                 new_data[CONF_PORT_WS] = port_ws
 
+            # Validate that port and port_ws are different
+            if new_data[CONF_PORT] == new_data.get(CONF_PORT_WS, DEFAULT_PORT_WS):
+                errors[CONF_PORT_WS] = "ports_must_differ"
+
             effects_submit: dict[str, str] = {}
-            async with create_hyperhdr_client(
-                new_data[CONF_HOST],
-                new_data[CONF_PORT],
-                token=new_data.get(CONF_TOKEN),
-                raw_connection=True,
-            ) as hyperhdr_client:
-                if not hyperhdr_client:
-                    errors[CONF_BASE] = "cannot_connect"
-                else:
-                    hyperhdr_id = await hyperhdr_client.async_sysinfo_id()
-                    unique_id = self._config_entry.unique_id
-                    if not hyperhdr_id:
-                        errors[CONF_BASE] = "no_id"
-                    elif unique_id and hyperhdr_id != unique_id:
-                        errors[CONF_BASE] = "wrong_device"
+            if not errors:
+                async with create_hyperhdr_client(
+                    new_data[CONF_HOST],
+                    new_data[CONF_PORT],
+                    token=new_data.get(CONF_TOKEN),
+                    raw_connection=True,
+                ) as hyperhdr_client:
+                    if not hyperhdr_client:
+                        errors[CONF_BASE] = "cannot_connect"
                     else:
-                        effects_submit = self._effects_map(hyperhdr_client)
+                        hyperhdr_id = await hyperhdr_client.async_sysinfo_id()
+                        unique_id = self._config_entry.unique_id
+                        if not hyperhdr_id:
+                            errors[CONF_BASE] = "no_id"
+                        elif unique_id and hyperhdr_id != unique_id:
+                            errors[CONF_BASE] = "wrong_device"
+                        else:
+                            effects_submit = self._effects_map(hyperhdr_client)
 
             if not errors:
                 effect_show_list = ui.pop(CONF_EFFECT_SHOW_LIST)

--- a/custom_components/hyperhdr/translations/en.json
+++ b/custom_components/hyperhdr/translations/en.json
@@ -12,7 +12,8 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "invalid_access_token": "Invalid access token"
+            "invalid_access_token": "Invalid access token",
+            "ports_must_differ": "JSON API port and WebSocket port must be different"
         },
         "step": {
             "auth": {
@@ -47,7 +48,8 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "no_id": "The HyperHDR Ambilight instance did not report its id",
-            "wrong_device": "This address is a different HyperHDR server. Remove this entry and add the new one instead."
+            "wrong_device": "This address is a different HyperHDR server. Remove this entry and add the new one instead.",
+            "ports_must_differ": "JSON API port and WebSocket port must be different"
         },
         "step": {
             "init": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes issue #104 where HTTP headers were being sent to the JSON API port (19444) when the WebSocket port was misconfigured to the same value.

## Problem

The HyperHDR JSON API (port 19444) expects raw JSON over TCP socket. However, when the WebSocket port (`port_ws`) is accidentally set to the same value as the JSON API port, the camera entities use aiohttp's `ws_connect` which sends HTTP upgrade headers to the raw TCP JSON endpoint, causing parse errors on the HyperHDR server:

```
Failed to parse json data from JsonRpc@::ffff:192.168.0.12: Error: illegal value at Line: 0, Column: 1, Data: 'Host: 192.168.0.100:19444
'
```

## Solution

1. **Config flow validation**: Added validation in both the user step and options flow to prevent setting `port_ws` equal to `port`, displaying a user-friendly error message

2. **Camera safety check**: Added a safety check in `camera.py` that skips camera entity creation if the ports match, logging a warning to help users identify the misconfiguration

3. **Translation**: Added error message translation for the new validation error

## Changes

- `custom_components/hyperhdr/config_flow.py`: Port validation in user and options flow
- `custom_components/hyperhdr/camera.py`: Safety check to prevent WebSocket connections to wrong port
- `custom_components/hyperhdr/translations/en.json`: New error message translation

## Testing

- Verified Python syntax is correct
- Logic prevents the misconfiguration scenario described in #104

Closes #104
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6e8c-b0c1-742b-bf7f-a132a697004d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6e8c-b0c1-742b-bf7f-a132a697004d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

